### PR TITLE
fix: volume average should be double

### DIFF
--- a/FinancialModelingPrepApi/Model/CompanyValuation/CompanyProfileResponse.cs
+++ b/FinancialModelingPrepApi/Model/CompanyValuation/CompanyProfileResponse.cs
@@ -14,7 +14,7 @@ namespace MatthiWare.FinancialModelingPrep.Model.CompanyValuation
         public double Beta { get; set; }
 
         [JsonPropertyName("volAvg")]
-        public int VolAvg { get; set; }
+        public double VolAvg { get; set; }
 
         [JsonPropertyName("mktCap")]
         public long MktCap { get; set; }


### PR DESCRIPTION
This endpoint threw an error for symbol BCS (Barclays). Their Volume Average is currently 14203535.8 so converting the int type to a double.

This would be a breaking change.