### PR TITLE
added from, to and extended query params to GetHistoricalPricesForChartWithVolume

### DIFF
--- a/FinancialModelingPrepApi/Abstractions/StockTimeSeries/IStockTimeSeriesProvider.cs
+++ b/FinancialModelingPrepApi/Abstractions/StockTimeSeries/IStockTimeSeriesProvider.cs
@@ -60,7 +60,10 @@ namespace MatthiWare.FinancialModelingPrep.Abstractions.StockTimeSeries
         /// </summary>
         /// <param name="symbol">Ticker symbol</param>
         /// <param name="series">Time series</param>
+        /// <param name="from">From date (YYYY-MM-DD)</param>
+        /// <param name="to">To date (YYYY-MM-DD)</param>
+        /// <param name="extended">Extended hours</param>
         /// <returns><see cref="HistoricalPriceForLineChartResponse"/></returns>
-        Task<ApiResponse<List<HistoricalPriceForChartWithVolumeResponse>>> GetHistoricalPricesForChartWithVolume(string symbol, HistoricalChartSeries series);
+        Task<ApiResponse<List<HistoricalPriceForChartWithVolumeResponse>>> GetHistoricalPricesForChartWithVolume(string symbol, HistoricalChartSeries series, string from, string to, bool extended);
     }
 }

--- a/FinancialModelingPrepApi/Core/StockTimeSeries/StockTimeSeriesProvider.cs
+++ b/FinancialModelingPrepApi/Core/StockTimeSeries/StockTimeSeriesProvider.cs
@@ -103,7 +103,7 @@ namespace MatthiWare.FinancialModelingPrep.Core.StockTimeSeries
         }
 
         /// <inheritdoc/>
-        public Task<ApiResponse<List<HistoricalPriceForChartWithVolumeResponse>>> GetHistoricalPricesForChartWithVolume(string symbol, HistoricalChartSeries series)
+        public Task<ApiResponse<List<HistoricalPriceForChartWithVolumeResponse>>> GetHistoricalPricesForChartWithVolume(string symbol, HistoricalChartSeries series, string from, string to, bool extended)
         {
             const string url = "[version]/historical-chart/[series]/[symbol]";
 
@@ -114,7 +114,12 @@ namespace MatthiWare.FinancialModelingPrep.Core.StockTimeSeries
                 { "symbol", symbol }
             };
 
-            return client.GetJsonAsync<List<HistoricalPriceForChartWithVolumeResponse>>(url, pathParams, null);
+            var queryString = new QueryStringBuilder();
+            queryString.Add("from", from);
+            queryString.Add("to", to);
+            queryString.Add("extended", extended ? "true" : "false");
+
+            return client.GetJsonAsync<List<HistoricalPriceForChartWithVolumeResponse>>(url, pathParams, queryString);
         }
 
         /// <inheritdoc/>

--- a/Tests/StockTimeSeries/StockTimeSeriesTests.cs
+++ b/Tests/StockTimeSeries/StockTimeSeriesTests.cs
@@ -109,9 +109,15 @@ namespace Tests.StockTimeSeries
         [MemberData(nameof(AvailableHistoricalChartSeries))]
         public async Task GetHistoricalPricesForChartWithVolume(HistoricalChartSeries series)
         {
-            var result = await api.GetHistoricalPricesForChartWithVolume("AAPL", series);
+            var fromDate = new DateTime(2025, 2, 2);
+            var toDate = new DateTime(2025, 2, 4);
+
+            var result = await api.GetHistoricalPricesForChartWithVolume("AAPL", series, fromDate.ToString("yyyy-MM-dd"), toDate.ToString("yyyy-MM-dd"), false);
 
             result.AssertNoErrors();
+            
+            Assert.Equal(toDate.Date, DateTime.Parse(result.Data.First().Date).Date);
+            Assert.Equal(fromDate.Date.AddDays(1), DateTime.Parse(result.Data.Last().Date).Date);
 
             Assert.True(result.Data.Count > 0);
         }
@@ -120,9 +126,35 @@ namespace Tests.StockTimeSeries
         [MemberData(nameof(AvailableHistoricalChartSeries))]
         public async Task GetHistoricalPricesForChartWithVolume2(HistoricalChartSeries series)
         {
-            var result = await api.GetHistoricalPricesForChartWithVolume("AGS.BR", series);
+            var fromDate = new DateTime(2025, 2, 2);
+            var toDate = new DateTime(2025, 2, 4);
+
+            var result = await api.GetHistoricalPricesForChartWithVolume("AGS.BR", series, fromDate.ToString("yyyy-MM-dd"), toDate.ToString("yyyy-MM-dd"), false);
 
             result.AssertNoErrors();
+
+            Assert.Equal(toDate.Date, DateTime.Parse(result.Data.First().Date).Date);
+            Assert.Equal(fromDate.Date.AddDays(1), DateTime.Parse(result.Data.Last().Date).Date);
+
+            Assert.True(result.Data.Count > 0);
+        }
+
+        [Theory]
+        [MemberData(nameof(AvailableHistoricalChartSeries))]
+        public async Task GetHistoricalPricesForChartWithVolumeExtended(HistoricalChartSeries series)
+        {
+            var fromDate = new DateTime(2025, 2, 2);
+            var toDate = new DateTime(2025, 2, 4);
+
+            var result = await api.GetHistoricalPricesForChartWithVolume("AAPL", series, fromDate.ToString("yyyy-MM-dd"), toDate.ToString("yyyy-MM-dd"), true);
+
+            result.AssertNoErrors();
+
+            Assert.Equal(toDate.Date, DateTime.Parse(result.Data.First().Date).Date);
+            Assert.Equal(fromDate.Date.AddDays(1), DateTime.Parse(result.Data.Last().Date).Date);
+
+            Assert.True(DateTime.Parse(result.Data.First().Date).Hour > 15);
+            Assert.True(DateTime.Parse(result.Data.Last().Date).Hour < 9);
 
             Assert.True(result.Data.Count > 0);
         }


### PR DESCRIPTION
[version]/historical-chart/[series]/[symbol] has 3 query params which was not available so far.
https://site.financialmodelingprep.com/developer/docs#chart-intraday
I added themi.