### PR TITLE
feat: add calendar year to key metrics response

### DIFF
--- a/FinancialModelingPrepApi/Model/CompanyValuation/KeyMetricsResponse.cs
+++ b/FinancialModelingPrepApi/Model/CompanyValuation/KeyMetricsResponse.cs
@@ -9,6 +9,9 @@ namespace MatthiWare.FinancialModelingPrep.Model.CompanyValuation
 
         [JsonPropertyName("date")]
         public string Date { get; set; }
+        
+        [JsonPropertyName("calendarYear")]
+        public string CalendarYear { get; set; }
 
         [JsonPropertyName("period")]
         public string Period { get; set; }


### PR DESCRIPTION
This property seems to be missing from the key metrics response.

to confirm, go to `https://financialmodelingprep.com/api/v3/key-metrics/AAPL?period=quarter` and see that calendarYear is a property